### PR TITLE
Use ipapi.co as ip-api.com appears to be offline

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -20,7 +20,7 @@ FAKE_API_BODY = json.dumps({'timezone': FAKE_TIMEZONE})
 
 
 def setup_basic_api_response(body=FAKE_API_BODY):
-    uri_regex = re.compile(r'^http://ip-api\.com/json/')
+    uri_regex = re.compile(r'^http://ipapi\.co/[0-9.]+/json/')
     httpretty.register_uri(
         httpretty.GET, uri_regex,
         body=body, content_type='application/json',

--- a/tzupdate.py
+++ b/tzupdate.py
@@ -26,7 +26,7 @@ def get_timezone_for_ip(ip_addr=None):
     current public IP address.
     '''
 
-    api_url = 'http://ip-api.com/json/{ip}'.format(ip=ip_addr or '')
+    api_url = 'http://ipapi.co/{ip}/json'.format(ip=ip_addr or '')
     log.debug('Making request to %s', api_url)
     api_response = requests.get(api_url).json()
     log.debug('API response: %r', api_response)


### PR DESCRIPTION
Looks like ip-api.com has gone offline and I'm not sure when/if it will be back. ipapi.co appears to be fast and gives the ip information in the same format.