### PR TITLE
print-sys-tz: Add print-system-timezone option and automatic timezone check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,12 @@ You can also see what tzupdate would do without actually doing it by passing
 ``-p``, and specify an alternative IP address by using ``-a``. This is not an
 exhaustive list of options, see ``tzupdate --help`` for that.
 
+The ``contrib/09-timezone`` script can be place in the
+``/etc/NetworkManager/dispatcher.d/`` folder. This script will automatically
+launch tzupdate upon network connection. The user will therefore be prompted to
+change the system timezone whenever the system connects to a network in a
+different timezone.
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -33,12 +33,6 @@ You can also see what tzupdate would do without actually doing it by passing
 ``-p``, and specify an alternative IP address by using ``-a``. This is not an
 exhaustive list of options, see ``tzupdate --help`` for that.
 
-The ``contrib/09-timezone`` script can be place in the
-``/etc/NetworkManager/dispatcher.d/`` folder. This script will automatically
-launch tzupdate upon network connection. The user will therefore be prompted to
-change the system timezone whenever the system connects to a network in a
-different timezone.
-
 Installation
 ------------
 

--- a/contrib/09-timezone
+++ b/contrib/09-timezone
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+if [ "$2" == "up" ]; then
+    TIMEZONE=$(tzupdate -p)
+    SYS_TZ=$(tzupdate --print-sys)
+
+    if [[ "$TIMEZONE" == "$SYS_TZ" ]]; then
+        echo "Timezone unchanged"
+        exit
+    fi
+
+    GDBUS_ARGS="--session
+          --dest org.freedesktop.Notifications
+          --object-path /org/freedesktop/Notifications"
+    NOTIFY_METHOD="--method org.freedesktop.Notifications.Notify"
+    SEND_NOTIF="gdbus call $GDBUS_ARGS $NOTIFY_METHOD tzupdate 0 '' 'Change timezone
+        to $TIMEZONE ?' '' '[\"changetz\", \"Yes\"]' '{\"urgency\": <byte 1>}'
+        'int32 -1'"
+    RECIEVE_ACTION="gdbus monitor $GDBUS_ARGS"
+    NOTIF_REGEXP='^\/org\/freedesktop\/Notifications: org.freedesktop.Notifications.\(.*\)$'
+
+    GDBUS_MONITOR_PID=$(mktemp)
+
+    USER=$(who | awk -v vt=tty$(fgconsole) '$0 ~ vt {print $1}')
+    export DISPLAY=$(w --from $USER | awk -F '  +' 'END{print $2}')
+    export XAUTHORITY=$(eval echo ~$USER/.Xauthority)
+    eval $(dbus-launch --auto-syntax)
+
+    NOTIFICATION_ID=$(eval $SEND_NOTIF | sed 's/(uint32 \([0-9]\+\),)/\1/g')
+
+    ( $RECIEVE_ACTION & echo $! >&3 ) 3>"$GDBUS_MONITOR_PID" | while read -r signal
+    do
+        recv="$(sed "s/$NOTIF_REGEXP/\\1/" <<< "$signal")"
+        if grep "NotificationClosed (uint32 $NOTIFICATION_ID, uint32 [0-9]\+)" <<< "$recv" &> /dev/null; then
+            break
+        fi
+        if [[ "$recv" == "ActionInvoked (uint32 $NOTIFICATION_ID, 'changetz')" ]]; then
+            tzupdate -t "$TIMEZONE"
+            break
+        fi
+    done
+    kill $(<"$GDBUS_MONITOR_PID")
+    rm -f $GDBUS_MONITOR_PID
+fi

--- a/contrib/09-timezone
+++ b/contrib/09-timezone
@@ -1,44 +1,52 @@
 #!/bin/sh
 
-if [ "$2" == "up" ]; then
+if [ "$2" = "up" ]; then
     TIMEZONE=$(tzupdate -p)
     SYS_TZ=$(tzupdate --print-sys)
 
-    if [[ "$TIMEZONE" == "$SYS_TZ" ]]; then
+    if [ "$TIMEZONE" = "$SYS_TZ" ]; then
         echo "Timezone unchanged"
         exit
     fi
 
-    GDBUS_ARGS="--session
-          --dest org.freedesktop.Notifications
-          --object-path /org/freedesktop/Notifications"
+    GDBUS_DEST="org.freedesktop.Notifications"
+    GDBUS_OBJ_PATH="/org/freedesktop/Notifications"
+    GDBUS_ARGS="--session --dest $GDBUS_DEST --object-path $GDBUS_OBJ_PATH"
+
     NOTIFY_METHOD="--method org.freedesktop.Notifications.Notify"
-    SEND_NOTIF="gdbus call $GDBUS_ARGS $NOTIFY_METHOD tzupdate 0 '' 'Change timezone
-        to $TIMEZONE ?' '' '[\"changetz\", \"Yes\"]' '{\"urgency\": <byte 1>}'
-        'int32 -1'"
+    NOTIF_SUMMARY="'Change timezone to $TIMEZONE ?'"
+    NOTIF_ACTIONS="'[\"changetz\", \"Yes\"]'"
+    NOTIF_HINTS="'{\"urgency\": <byte 1>}'"
+    NOTIF_ARGS="tzupdate 0 '' $NOTIF_SUMMARY '' $NOTIF_ACTIONS $NOTIF_HINTS 'int32 -1'"
+    SEND_NOTIF="gdbus call $GDBUS_ARGS $NOTIFY_METHOD $NOTIF_ARGS"
+
     RECIEVE_ACTION="gdbus monitor $GDBUS_ARGS"
-    NOTIF_REGEXP='^\/org\/freedesktop\/Notifications: org.freedesktop.Notifications.\(.*\)$'
+    NOTIF_REGEXP="^$GDBUS_OBJ_PATH: $GDBUS_DEST.\\(.*\\)$"
 
     GDBUS_MONITOR_PID=$(mktemp)
 
-    USER=$(who | awk -v vt=tty$(fgconsole) '$0 ~ vt {print $1}')
-    export DISPLAY=$(w --from $USER | awk -F '  +' 'END{print $2}')
-    export XAUTHORITY=$(eval echo ~$USER/.Xauthority)
-    eval $(dbus-launch --auto-syntax)
+    USER=$(who | awk -v vt=tty"$(fgconsole)" '$0 ~ vt {print $1}')
+    DISPLAY=$(w --from "$USER" | awk -F '  +' 'END{print $2}')
+    XAUTHORITY=$(eval echo ~"$USER"/.Xauthority)
 
-    NOTIFICATION_ID=$(eval $SEND_NOTIF | sed 's/(uint32 \([0-9]\+\),)/\1/g')
+    export DISPLAY
+    export XAUTHORITY
+    eval "$(dbus-launch --auto-syntax)"
+
+    NOTIF_ID=$(eval "$SEND_NOTIF" | sed 's/(uint32 \([0-9]\+\),)/\1/g')
+    NOTIF_CLOSE_REGEXP="^NotificationClosed (uint32 $NOTIF_ID, uint32 [0-9]\+)$"
 
     ( $RECIEVE_ACTION & echo $! >&3 ) 3>"$GDBUS_MONITOR_PID" | while read -r signal
     do
-        recv="$(sed "s/$NOTIF_REGEXP/\\1/" <<< "$signal")"
-        if grep "NotificationClosed (uint32 $NOTIFICATION_ID, uint32 [0-9]\+)" <<< "$recv" &> /dev/null; then
+        recv="$(printf '%s' "$signal" | sed "s~$NOTIF_REGEXP~\\1~")"
+        if printf '%s' "$recv" | grep "$NOTIF_CLOSE_REGEXP" >/dev/null 2>&1; then
             break
         fi
-        if [[ "$recv" == "ActionInvoked (uint32 $NOTIFICATION_ID, 'changetz')" ]]; then
+        if [ "$recv" = "ActionInvoked (uint32 $NOTIF_ID, 'changetz')" ]; then
             tzupdate -t "$TIMEZONE"
             break
         fi
     done
-    kill $(<"$GDBUS_MONITOR_PID")
-    rm -f $GDBUS_MONITOR_PID
+    kill "$(cat "$GDBUS_MONITOR_PID")"
+    rm -f "$GDBUS_MONITOR_PID"
 fi

--- a/contrib/README.rst
+++ b/contrib/README.rst
@@ -1,0 +1,9 @@
+Automatic timezone change detection with NetworkManager
+=======================================================
+
+The ``09-timezone`` script can be placed in the
+``/etc/NetworkManager/dispatcher.d/`` folder. This script will automatically
+launch tzupdate upon network connection. The user will therefore be prompted to
+change the system timezone whenever the system connects to a network in a
+different timezone. You also need a notification server with action support
+like ``xfce4-notifyd`` for instance.

--- a/tests/_test_utils.py
+++ b/tests/_test_utils.py
@@ -13,6 +13,7 @@ IP_ADDRESSES = builds(
 ).map(str)
 
 FAKE_TIMEZONE = "Fake/Timezone"
+FAKE_ZONEINFO_PATH = "/path/to/zoneinfo"
 FAKE_ERROR = "Virus = very yes"
 
 FAKE_SERVICES = [

--- a/tests/e2e_tests.py
+++ b/tests/e2e_tests.py
@@ -36,6 +36,17 @@ def test_print_only_no_link(link_localtime_mock, deb_tz_mock):
 @httpretty.activate
 @mock.patch("tzupdate.write_debian_timezone")
 @mock.patch("tzupdate.link_localtime")
+def test_print_sys_tz_no_link(link_localtime_mock, deb_tz_mock):
+    setup_basic_api_response()
+    args = ["--print-system-timezone"]
+    tzupdate.main(args, services=FAKE_SERVICES)
+    assert_false(link_localtime_mock.called)
+    assert_false(deb_tz_mock.called)
+
+
+@httpretty.activate
+@mock.patch("tzupdate.write_debian_timezone")
+@mock.patch("tzupdate.link_localtime")
 def test_explicit_paths(link_localtime_mock, deb_tz_mock):
     setup_basic_api_response()
     localtime_path = "/l"

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -9,6 +9,7 @@ from tests._test_utils import (
     IP_ADDRESSES,
     FAKE_SERVICES,
     FAKE_TIMEZONE,
+    FAKE_ZONEINFO_PATH,
     setup_basic_api_response,
 )
 from nose.tools import assert_raises, eq_ as eq, assert_true, assert_is_none, assert_in
@@ -32,6 +33,13 @@ def test_get_timezone_for_ip(ip, service):
         assert_in(ip, httpretty.last_request().path)
 
     fake_queue.put.assert_called_once_with(FAKE_TIMEZONE)
+
+
+def test_get_sys_timezone():
+    systz = tzupdate.get_sys_timezone(
+        FAKE_ZONEINFO_PATH, FAKE_ZONEINFO_PATH + "/" + FAKE_TIMEZONE
+    )
+    assert systz == FAKE_TIMEZONE
 
 
 @httpretty.activate

--- a/tzupdate.py
+++ b/tzupdate.py
@@ -179,9 +179,7 @@ def link_localtime(timezone, zoneinfo_path, localtime_path):
 
 
 def get_sys_timezone(zoneinfo_abspath, localtime_abspath):
-    return localtime_abspath.replace(
-        os.path.commonpath([zoneinfo_abspath, localtime_abspath]) + "/", "", 1
-    )
+    return localtime_abspath.replace(zoneinfo_abspath + os.path.sep, "", 1)
 
 
 def parse_args(argv):

--- a/tzupdate.py
+++ b/tzupdate.py
@@ -179,7 +179,9 @@ def link_localtime(timezone, zoneinfo_path, localtime_path):
 
 
 def get_sys_timezone(zoneinfo_abspath, localtime_abspath):
-    return localtime_abspath.replace(zoneinfo_abspath + os.path.sep, "", 1)
+    return localtime_abspath.replace(
+        os.path.commonprefix([zoneinfo_abspath, localtime_abspath]) + os.path.sep, "", 1
+    )
 
 
 def parse_args(argv):

--- a/tzupdate.py
+++ b/tzupdate.py
@@ -177,6 +177,9 @@ def link_localtime(timezone, zoneinfo_path, localtime_path):
 
     return zoneinfo_tz_path
 
+def get_sys_timezone(zoneinfo_abspath, localtime_abspath):
+    return localtime_abspath.replace(os.path.commonpath(
+        [zoneinfo_abspath, localtime_abspath]) + '/', '', 1)
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(description=__doc__)
@@ -185,6 +188,11 @@ def parse_args(argv):
         "--print-only",
         action="store_true",
         help="print the timezone, but don't update the localtime file",
+    )
+    parser.add_argument(
+        "--print-system-timezone",
+        action="store_true",
+        help="print the current system timezone",
     )
     parser.add_argument(
         "-a", "--ip", help="use this IP instead of automatically detecting it"
@@ -238,6 +246,11 @@ def main(argv=None, services=SERVICES):
 
     args = parse_args(argv)
     logging.basicConfig(level=args.log_level)
+
+    if args.print_system_timezone:
+        print(get_sys_timezone(os.path.realpath(args.zoneinfo_path),
+                               os.path.realpath(args.localtime_path)))
+        return
 
     if args.timezone:
         timezone = args.timezone

--- a/tzupdate.py
+++ b/tzupdate.py
@@ -177,9 +177,12 @@ def link_localtime(timezone, zoneinfo_path, localtime_path):
 
     return zoneinfo_tz_path
 
+
 def get_sys_timezone(zoneinfo_abspath, localtime_abspath):
-    return localtime_abspath.replace(os.path.commonpath(
-        [zoneinfo_abspath, localtime_abspath]) + '/', '', 1)
+    return localtime_abspath.replace(
+        os.path.commonpath([zoneinfo_abspath, localtime_abspath]) + "/", "", 1
+    )
+
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(description=__doc__)
@@ -248,8 +251,12 @@ def main(argv=None, services=SERVICES):
     logging.basicConfig(level=args.log_level)
 
     if args.print_system_timezone:
-        print(get_sys_timezone(os.path.realpath(args.zoneinfo_path),
-                               os.path.realpath(args.localtime_path)))
+        print(
+            get_sys_timezone(
+                os.path.realpath(args.zoneinfo_path),
+                os.path.realpath(args.localtime_path),
+            )
+        )
         return
 
     if args.timezone:


### PR DESCRIPTION
This adds the `ask-before-change` option which asks the user if he wants to apply the timezone change or not.
This is particularly useful when combined with the `09-timezone` script which automatically launches tzupdate upon network connection.
The user is therefore prompted to change the system timezone whenever the system connects to a network in a different timezone.

Signed-off-by: Julien DOCHE <julien.doche@gmail.com>