### PR TITLE
Explicitly use python3

### DIFF
--- a/tzupdate.py
+++ b/tzupdate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Set the system timezone based on IP geolocation.


### PR DESCRIPTION
tzupdate.py doesn't work with python2, so should explicitly specify that instead of
relying on "python" to be linked/aliased to "python3" (e.g. via the python-is-python3
package, which may not even exist).