### PR TITLE
Added IPinfo.io as a source for timezone information through IP Geolocation.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -37,6 +37,10 @@ static SERVICES: &[GeoIPService] = &[
         url: "https://ipwho.is/{ip}",
         tz_keys: &["timezone", "id"],
     },
+    GeoIPService {
+        url: "https://ipinfo.io/{ip}/json",
+        tz_keys: &["timezone"],
+    },
 ];
 
 /// Given &["foo", "bar", "baz"], retrieve the value at data["foo"]["bar"]["baz"].


### PR DESCRIPTION
Hi,

I am the DevRel of IPinfo, and I have added [IPinfo.io](;https://ipinfo.io/) as a source for timezone information. The API response is fairly standard, so I don't think there would be any issues. The timezone information is returned in the IANA Time Zone Database format.

> IPinfo API request

```
curl https://ipinfo.io/2.43.176.103/json
```

> API response

```
{
    "ip": "2.43.176.103",
    "hostname": "mob-2-43-176-103.net.vodafone.it",
    "city": "Palermo",
    "region": "Sicily",
    "country": "IT",
    "loc": "38.1166,13.3636",
    "org": "AS30722 Vodafone Italia S.p.A.",
    "postal": "90100",
    "timezone": "Europe/Rome", <==========
    "readme": "https://ipinfo.io/missingauth"
}
```

Also, it is highly unlikely that our API will get timed out or throw any rate-related issues. Without the token, we support up to 1,000 requests per day.

Let me know if there are any issues. We would be very happy if the PR gets merged. Thanks!